### PR TITLE
Drop rubocop from gemspec

### DIFF
--- a/rom-influxdb.gemspec
+++ b/rom-influxdb.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
The CI Rake task does not use RuboCop and Bundler (rightfully so) whines about rubocop being in both the gemspec and Gemfile. This drops it from the gemspec (so CI doesn’t need to install it).
